### PR TITLE
Allow passing of rsync options in connection.copy

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -121,7 +121,8 @@ Connection.prototype.copy = function (src, dest, options, cb) {
 
   options = _.defaults(options || {}, {
     maxBuffer: 1000 * 1024,
-    direction: 'localToRemote'
+    direction: 'localToRemote',
+    rsync: []
   });
 
   var connection = this;
@@ -141,9 +142,11 @@ Connection.prototype.copy = function (src, dest, options, cb) {
     // Format excludes.
     var excludes = options.ignores ? formatExcludes(options.ignores) : [];
 
+    // Append options to rsync command.
+    var rsyncOptions = excludes.concat(['-az']).concat(options.rsync);
+
     // Build command.
-    var args = ['rsync'].concat(excludes).concat([
-      '-az',
+    var args = ['rsync'].concat(rsyncOptions).concat([
       '-e',
       '"ssh ' + connection.sshArgs.join(' ') + '"',
       completeSrc,
@@ -204,8 +207,8 @@ function buildSSHArgs(options) {
 
   if (options.key)
     args = args.concat(['-i', options.key]);
-    
-  if (options.strict) 
+
+  if (options.strict)
     args = args.concat(['-o',  'StrictHostKeyChecking=' + options.strict]);
 
   return args;

--- a/test/connection-pool.js
+++ b/test/connection-pool.js
@@ -80,12 +80,12 @@ describe('SSH Connection pool', function () {
 
         expect(childProcess.exec).to.be.calledWith(
           'rsync -az -e "ssh " /src/dir deploy@myserver:/dest/dir',
-          {maxBuffer: 1000 * 1024}
+          {maxBuffer: 1000 * 1024, rsync: []}
         );
 
         expect(childProcess.exec).to.be.calledWith(
           'rsync -az -e "ssh " /src/dir deploy@myserver2:/dest/dir',
-          {maxBuffer: 1000 * 1024}
+          {maxBuffer: 1000 * 1024, rsync: []}
         );
 
         done();

--- a/test/connection.js
+++ b/test/connection.js
@@ -114,11 +114,11 @@ describe('SSH Connection', function () {
         'ssh -p 12345 user@host "my-command -x"'
       );
     });
-    
+
     it('should use StrictHostKeyChecking if present', function () {
       connection = new Connection({
         remote: 'user@host',
-        strict: 'no' 
+        strict: 'no'
       });
       connection.run('my-command -x', function () {});
       expect(childProcess.exec).to.be.calledWith(
@@ -194,6 +194,12 @@ describe('SSH Connection', function () {
       expect(childProcess.exec).to.be.calledWith('rsync -az -e "ssh " user@host:/src/dir /dest/dir');
     });
 
+    it('should accept "rsync" option', function (done) {
+      connection.copy('/src/dir', '/dest/dir', {rsync: '--info=progress2'}, done);
+
+      expect(childProcess.exec).to.be.calledWith('rsync -az --info=progress2 -e "ssh " /src/dir user@host:/dest/dir');
+    });
+
     it('should use key if present', function (done) {
       connection = new Connection({
         remote: 'user@host',
@@ -210,11 +216,11 @@ describe('SSH Connection', function () {
       connection.copy('/src/dir', '/dest/dir', done);
       expect(childProcess.exec).to.be.calledWith('rsync -az -e "ssh -p 12345" /src/dir user@host:/dest/dir');
     });
-    
+
     it('should use StrictHostKeyChecking if present', function (done) {
       connection = new Connection({
         remote: 'user@host',
-        strict: 'yes' 
+        strict: 'yes'
       });
       connection.copy('/src/dir', '/dest/dir', done);
       expect(childProcess.exec).to.be.calledWith('rsync -az -e "ssh -o StrictHostKeyChecking=yes" /src/dir user@host:/dest/dir');


### PR DESCRIPTION
Specifically, I'd like this so I can pass `--info=progress2` or `--progress` to `shipit.copy`
