### PR TITLE
Add support for Connection.copy() on windows (in an msysgit environment)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -1,7 +1,9 @@
 var _ = require('lodash');
+var path = require('path');
 var exec = require('child_process').exec;
 var LineWrapper = require('stream-line-wrapper');
 var Promise = require('bluebird');
+var whereis = require('whereis');
 var remote = require('./remote');
 
 // Expose connection.
@@ -40,6 +42,30 @@ Connection.prototype.log = function () {
 };
 
 /**
+ * Builds a command that will be executed remotely through SSH
+ * @param {string} command
+ * @returns {string}
+ */
+Connection.prototype.buildSshCommand = function (command) {
+
+  var connection = this;
+
+  // In sudo mode, we use a TTY channel.
+  var args = /^sudo/.exec(command) ? ['-tt'] : [];
+  args.push.apply(args, connection.sshArgs);
+  args.push(remote.format(connection.remote));
+
+  // Escape double quotes in command.
+  command = command.replace(/"/g, '\\"');
+
+  // Complete arguments.
+  args = ['ssh'].concat(args).concat(['"' + command + '"']);
+
+  return args.join(' ');
+
+};
+
+/**
  * Run a new SSH command.
  *
  * @param {string} command Command
@@ -64,24 +90,13 @@ Connection.prototype.run = function (command, options, cb) {
   return new Promise(function (resolve, reject) {
     connection.log('Running "%s" on host "%s".', command, connection.remote.host);
 
-    // In sudo mode, we use a TTY channel.
-    var args = /^sudo/.exec(command) ? ['-tt'] : [];
-    args.push.apply(args, connection.sshArgs);
-    args.push(remote.format(connection.remote));
-
-    // Escape double quotes in command.
-    command = command.replace(/"/g, '\\"');
-
-    // Complete arguments.
-    args = ['ssh'].concat(args).concat(['"' + command + '"']);
-
     // Log wrappers.
     var stdoutWrapper = new LineWrapper({prefix: '@' + connection.remote.host + ' '});
     var stderrWrapper = new LineWrapper({prefix: '@' + connection.remote.host + '-err '});
 
     // Exec command.
     var child = exec(
-      args.join(' '),
+      connection.buildSshCommand(command),
       options,
       function(err, stdout, stderr) {
         if (err) return reject(err);
@@ -127,53 +142,100 @@ Connection.prototype.copy = function (src, dest, options, cb) {
 
   var connection = this;
 
-  return new Promise(function (resolve, reject) {
+  return isRsyncAvailable().then(function (rsyncAvailable) {
 
-    // Complete src.
-    var completeSrc = options.direction === 'remoteToLocal' ?
+    return new Promise(function (resolve, reject) {
+
+      // Complete src.
+      var completeSrc = options.direction === 'remoteToLocal' ?
       remote.format(connection.remote) + ':' + src :
-      src;
+        src;
 
-    // Complete dest.
-    var completeDest = options.direction === 'localToRemote' ?
+      // Complete dest.
+      var completeDest = options.direction === 'localToRemote' ?
       remote.format(connection.remote) + ':' + dest :
-      dest;
+        dest;
 
-    // Format excludes.
-    var excludes = options.ignores ? formatExcludes(options.ignores) : [];
+      // Format excludes.
+      var excludes = options.ignores ? formatExcludes(options.ignores) : [];
 
-    // Append options to rsync command.
-    var rsyncOptions = excludes.concat(['-az']).concat(options.rsync);
+      var cmd = null;
 
-    // Build command.
-    var args = ['rsync'].concat(rsyncOptions).concat([
-      '-e',
-      '"ssh ' + connection.sshArgs.join(' ') + '"',
-      completeSrc,
-      completeDest
-    ]);
+      if (rsyncAvailable && !options.useShim) {
 
-    connection.log('Remote copy "%s" to "%s"', completeSrc, completeDest);
+        // Append options to rsync command.
+        var rsyncOptions = excludes.concat(['-az']).concat(options.rsync);
 
-    // Log wrappers.
-    var stdoutWrapper = new LineWrapper({prefix: '@' + connection.remote.host + ' '});
-    var stderrWrapper = new LineWrapper({prefix: '@' + connection.remote.host + '-err '});
+        // Build command.
+        cmd = ['rsync'].concat(rsyncOptions).concat([
+          '-e',
+          '"ssh ' + connection.sshArgs.join(' ') + '"',
+          completeSrc,
+          completeDest
+        ]).join(' ');
 
-    // Exec command.
-    var child = exec(args.join(' '), _.omit(options, 'direction'), function (err, stdout, stderr) {
-      if (err) return reject(err);
-      resolve({
-        child: child,
-        stdout: stdout,
-        stderr: stderr
+      } else {
+
+        var pkgname = path.basename(src) + '.tar.gz';
+
+        var tarCd = ['cd', path.dirname(src)].join(' ');
+
+        var tar = [tarCd, ['tar'].concat(excludes).concat('-czf', pkgname, path.basename(src)).join(' ')].join('; ');
+        if (options.direction === 'remoteToLocal')
+          tar = connection.buildSshCommand(tar);
+
+        var fromFile = options.direction === 'localToRemote' ?
+        path.dirname(src) + '/' + pkgname :
+        remote.format(connection.remote) + ':' + path.dirname(src) + '/' + pkgname;
+
+        var toFile = options.direction === 'remoteToLocal' ?
+          path.dirname(dest) :
+        remote.format(connection.remote) + ':' + path.dirname(dest);
+
+        var scp = ['scp'];
+
+        if (connection.remote.port)
+          scp = scp.concat('-P', connection.remote.port);
+
+        if (connection.remote.key)
+          scp = scp.concat('-i', connection.remote.key);
+
+        scp = scp.concat(fromFile, toFile);
+
+        var untarCd = ['cd', path.dirname(dest)].join(' ');
+
+        var untar = [untarCd, ['tar'].concat('-xzf', pkgname).join(' ')].join('; ');
+        if (options.direction === 'localToRemote')
+          untar = connection.buildSshCommand(untar);
+
+        cmd = [tar, scp.join(' '), untar].join('; ');
+
+      }
+
+      connection.log('Remote copy "%s" to "%s"', completeSrc, completeDest);
+
+      // Log wrappers.
+      var stdoutWrapper = new LineWrapper({prefix: '@' + connection.remote.host + ' '});
+      var stderrWrapper = new LineWrapper({prefix: '@' + connection.remote.host + '-err '});
+
+      // Exec command.
+      var child = exec(cmd, _.omit(options, 'direction'), function (err, stdout, stderr) {
+        if (err) return reject(err);
+        resolve({
+          child:  child,
+          stdout: stdout,
+          stderr: stderr
+        });
       });
-    });
 
-    if (connection.options.stdout)
-      child.stdout.pipe(stdoutWrapper).pipe(connection.options.stdout);
+      if (connection.options.stdout)
+        child.stdout.pipe(stdoutWrapper).pipe(connection.options.stdout);
 
-    if (connection.options.stderr)
-      child.stderr.pipe(stderrWrapper).pipe(connection.options.stderr);
+      if (connection.options.stderr)
+        child.stderr.pipe(stderrWrapper).pipe(connection.options.stderr);
+
+    })
+
   }).nodeify(cb);
 };
 
@@ -188,6 +250,19 @@ function formatExcludes(excludes) {
   return excludes.reduce(function (prev, current) {
     return prev.concat(['--exclude', '"' + current + '"']);
   }, []);
+}
+
+/**
+ * Checks whether the rsync binary is available
+ *
+ * @returns {Promise.<boolean>}
+ */
+function isRsyncAvailable() {
+  return new Promise(function (resolve) {
+    whereis('rsync', function (err, path) {
+      resolve(!err);
+    });
+  });
 }
 
 /**

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -219,29 +219,29 @@ function generateScpCommands(options, connection, src, dest) {
   // Format excludes.
   var excludes = options.ignores ? formatExcludes(options.ignores) : [];
 
-  var pkgname = sprintf('%s.tmp.tar.gz', path.basename(src));
-  var fromFile = generatePath(path.dirname(src) + '/' + pkgname, 'src');
-  var toFile = generatePath(dest, 'dest');
+  var packageFile = sprintf('%s.tmp.tar.gz', path.basename(src));
+  var fromPath = generatePath(path.dirname(src) + '/' + packageFile, 'src');
+  var toPath = generatePath(dest, 'dest');
 
-  var tarCd = ['cd', path.dirname(src)].join(' ');
-  var untarCd = ['cd', dest].join(' ');
+  var cdSource = ['cd', path.dirname(src)].join(' ');
+  var cdDest = ['cd', dest].join(' ');
 
   var tar = generateCommand(
-    [tarCd, ['tar'].concat(excludes).concat('-czf', pkgname, path.basename(src)).join(' ')].join(' && '),
+    [cdSource, ['tar'].concat(excludes).concat('-czf', packageFile, path.basename(src)).join(' ')].join(' && '),
     'src');
 
   // The command to untar the destination package
   var untar = generateCommand(
-    [untarCd, ['tar'].concat('--strip-components', '1', '-xzf', pkgname).join(' ')].join(' && '),
+    [cdDest, ['tar'].concat('--strip-components', '1', '-xzf', packageFile).join(' ')].join(' && '),
     'dest');
 
   return [
     tar,
     generateCommand(['mkdir', '-p', dest].join(' '), 'dest'),
-    buildSCPCommand(connection, fromFile, toFile),
-    generateCommand([tarCd, ['rm', pkgname].join(' ')].join(' && '), 'src'),
+    buildSCPCommand(connection, fromPath, toPath),
+    generateCommand([cdSource, ['rm', packageFile].join(' ')].join(' && '), 'src'),
     untar,
-    generateCommand([untarCd, ['rm', pkgname].join(' ')].join(' && '), 'dest')
+    generateCommand([cdDest, ['rm', packageFile].join(' ')].join(' && '), 'dest')
   ];
 }
 
@@ -259,8 +259,8 @@ function copyViaScp(options, connection, src, dest) {
 
   var cmdOptions = _.omit(options, 'direction');
 
+  // Executes an array of commands in series
   return Promise.reduce(commands, function (results, cmd) {
-    //console.log(cmd);
     return execCommand(connection, cmd, cmdOptions).then(function (res) {
       results.stdout += res.stdout;
       results.stderr += res.stderr;
@@ -368,10 +368,12 @@ function buildSSHArgs(options) {
  * @returns {string}
  */
 function buildSCPCommand(connection, from, to) {
-  // The command that transfers the file
+
   var scp = ['scp'];
+
   if (connection.remote.port) scp = scp.concat('-P', connection.remote.port);
   if (connection.options.key) scp = scp.concat('-i', connection.options.key);
-  scp = scp.concat(from, to).join(' ');
-  return scp;
+
+  return scp.concat(from, to).join(' ');
+
 }

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -4,6 +4,7 @@ var exec = require('child_process').exec;
 var LineWrapper = require('stream-line-wrapper');
 var Promise = require('bluebird');
 var whereis = require('whereis');
+var sprintf = require('sprintf-js').sprintf;
 var remote = require('./remote');
 
 // Expose connection.
@@ -95,8 +96,10 @@ Connection.prototype.run = function (command, options, cb) {
     var stderrWrapper = new LineWrapper({prefix: '@' + connection.remote.host + '-err '});
 
     // Exec command.
+    var cmd = connection.buildSshCommand(command);
+
     var child = exec(
-      connection.buildSshCommand(command),
+      cmd,
       options,
       function(err, stdout, stderr) {
         if (err) return reject(err);
@@ -115,6 +118,160 @@ Connection.prototype.run = function (command, options, cb) {
       child.stderr.pipe(stderrWrapper).pipe(connection.options.stderr);
   }).nodeify(cb);
 };
+
+/**
+ * Executes the given command with child_process.exec, appropriately transforming the stdout and stderr streams
+ * @param {Connection} connection The associated connection object (used exclusively for output decoration)
+ * @param {string} cmd
+ * @param {Object} cmdOptions Array of options passed to child_process.exec
+ * @returns {Promise}
+ */
+function execCommand(connection, cmd, cmdOptions) {
+
+  return new Promise(function (resolve, reject) {
+
+    // Exec command.
+    var child = exec(cmd, cmdOptions, function (err, stdout, stderr) {
+      if (err) reject(err);
+      else
+        resolve({
+          child:  child,
+          stdout: stdout,
+          stderr: stderr
+        });
+    });
+
+    if (connection.options.stdout)
+      child.stdout
+        .pipe(new LineWrapper({prefix: '@' + connection.remote.host + ' '}))
+        .pipe(connection.options.stdout);
+
+    if (connection.options.stderr)
+      child.stderr
+        .pipe(new LineWrapper({prefix: '@' + connection.remote.host + '-err '}))
+        .pipe(connection.options.stderr);
+
+  });
+
+}
+
+/**
+ * Performs the copy operation via rsync
+ * @param {Object} options
+ * @param {Connection} connection
+ * @param {string} src
+ * @param {string} dest
+ * @returns {Promise}
+ */
+function copyViaRsync(options, connection, src, dest) {
+
+  // Complete src.
+  var completeSrc = options.direction === 'remoteToLocal' ?
+  remote.format(connection.remote) + ':' + src :
+    src;
+
+  // Complete dest.
+  var completeDest = options.direction === 'localToRemote' ?
+  remote.format(connection.remote) + ':' + dest :
+    dest;
+
+  connection.log('Copy "%s" to "%s" via rsync', completeSrc, completeDest);
+
+  // Format excludes.
+  var excludes = options.ignores ? formatExcludes(options.ignores) : [];
+
+  // Append options to rsync command.
+  var rsyncOptions = excludes.concat(['-az']).concat(options.rsync);
+
+  // Build command.
+  var cmd = ['rsync'].concat(rsyncOptions).concat([
+    '-e',
+    '"ssh ' + connection.sshArgs.join(' ') + '"',
+    completeSrc,
+    completeDest
+  ]).join(' ');
+
+  var cmdOptions = _.omit(options, 'direction');
+
+  return execCommand(connection, cmd, cmdOptions);
+
+}
+
+/**
+ * Generates an array of commands to use when copying over scp
+ * @param {Object} options
+ * @param {Connection} connection
+ * @param {string} src
+ * @param {string} dest
+ * @returns {string[]}
+ */
+function generateScpCommands(options, connection, src, dest) {
+  var generateCommand = function (cmd, dest) {
+    return (options.direction === 'remoteToLocal' && dest === 'dest' || options.direction === 'localToRemote' && dest === 'src') ?
+      cmd : connection.buildSshCommand(cmd);
+  };
+
+  var generatePath = function (path, dest) {
+    return (options.direction === 'remoteToLocal' && dest === 'dest' || options.direction === 'localToRemote' && dest === 'src') ?
+      path : remote.format(connection.remote) + ':' + path;
+  };
+
+  // Format excludes.
+  var excludes = options.ignores ? formatExcludes(options.ignores) : [];
+
+  var pkgname = sprintf('%s.tmp.tar.gz', path.basename(src));
+  var fromFile = generatePath(path.dirname(src) + '/' + pkgname, 'src');
+  var toFile = generatePath(dest, 'dest');
+
+  var tarCd = ['cd', path.dirname(src)].join(' ');
+  var untarCd = ['cd', dest].join(' ');
+
+  var tar = generateCommand(
+    [tarCd, ['tar'].concat(excludes).concat('-czf', pkgname, path.basename(src)).join(' ')].join(' && '),
+    'src');
+
+  // The command to untar the destination package
+  var untar = generateCommand(
+    [untarCd, ['tar'].concat('--strip-components', '1', '-xzf', pkgname).join(' ')].join(' && '),
+    'dest');
+
+  return [
+    tar,
+    generateCommand(['mkdir', '-p', dest].join(' '), 'dest'),
+    buildSCPCommand(connection, fromFile, toFile),
+    generateCommand([tarCd, ['rm', pkgname].join(' ')].join(' && '), 'src'),
+    untar,
+    generateCommand([untarCd, ['rm', pkgname].join(' ')].join(' && '), 'dest')
+  ];
+}
+
+/**
+ * Performs the copy operation via tar+scp
+ * @param {Object} options
+ * @param {Connection} connection
+ * @param {string} src
+ * @param {string} dest
+ * @returns {Promise}
+ */
+function copyViaScp(options, connection, src, dest) {
+
+  var commands = generateScpCommands(options, connection, src, dest);
+
+  var cmdOptions = _.omit(options, 'direction');
+
+  return Promise.reduce(commands, function (results, cmd) {
+    //console.log(cmd);
+    return execCommand(connection, cmd, cmdOptions).then(function (res) {
+      results.stdout += res.stdout;
+      results.stderr += res.stderr;
+      return results;
+    });
+  }, {
+    stdout: '',
+    stderr: ''
+  });
+
+}
 
 /**
  * Remote file copy.
@@ -137,106 +294,19 @@ Connection.prototype.copy = function (src, dest, options, cb) {
   options = _.defaults(options || {}, {
     maxBuffer: 1000 * 1024,
     direction: 'localToRemote',
-    rsync: []
+    rsync:     []
   });
-
-  var connection = this;
 
   return isRsyncAvailable().then(function (rsyncAvailable) {
 
     return new Promise(function (resolve, reject) {
 
-      // Complete src.
-      var completeSrc = options.direction === 'remoteToLocal' ?
-      remote.format(connection.remote) + ':' + src :
-        src;
+      var copy = rsyncAvailable ? copyViaRsync : copyViaScp;
+      resolve(copy(options, this, src, dest));
 
-      // Complete dest.
-      var completeDest = options.direction === 'localToRemote' ?
-      remote.format(connection.remote) + ':' + dest :
-        dest;
+    }.bind(this))
 
-      // Format excludes.
-      var excludes = options.ignores ? formatExcludes(options.ignores) : [];
-
-      var cmd = null;
-
-      if (rsyncAvailable && !options.useShim) {
-
-        // Append options to rsync command.
-        var rsyncOptions = excludes.concat(['-az']).concat(options.rsync);
-
-        // Build command.
-        cmd = ['rsync'].concat(rsyncOptions).concat([
-          '-e',
-          '"ssh ' + connection.sshArgs.join(' ') + '"',
-          completeSrc,
-          completeDest
-        ]).join(' ');
-
-      } else {
-
-        var pkgname = path.basename(src) + '.tar.gz';
-
-        var tarCd = ['cd', path.dirname(src)].join(' ');
-
-        var tar = [tarCd, ['tar'].concat(excludes).concat('-czf', pkgname, path.basename(src)).join(' ')].join('; ');
-        if (options.direction === 'remoteToLocal')
-          tar = connection.buildSshCommand(tar);
-
-        var fromFile = options.direction === 'localToRemote' ?
-        path.dirname(src) + '/' + pkgname :
-        remote.format(connection.remote) + ':' + path.dirname(src) + '/' + pkgname;
-
-        var toFile = options.direction === 'remoteToLocal' ?
-          path.dirname(dest) :
-        remote.format(connection.remote) + ':' + path.dirname(dest);
-
-        var scp = ['scp'];
-
-        if (connection.remote.port)
-          scp = scp.concat('-P', connection.remote.port);
-
-        if (connection.remote.key)
-          scp = scp.concat('-i', connection.remote.key);
-
-        scp = scp.concat(fromFile, toFile);
-
-        var untarCd = ['cd', path.dirname(dest)].join(' ');
-
-        var untar = [untarCd, ['tar'].concat('-xzf', pkgname).join(' ')].join('; ');
-        if (options.direction === 'localToRemote')
-          untar = connection.buildSshCommand(untar);
-
-        cmd = [tar, scp.join(' '), untar].join('; ');
-
-      }
-
-      connection.log('Remote copy "%s" to "%s"', completeSrc, completeDest);
-
-      // Log wrappers.
-      var stdoutWrapper = new LineWrapper({prefix: '@' + connection.remote.host + ' '});
-      var stderrWrapper = new LineWrapper({prefix: '@' + connection.remote.host + '-err '});
-
-      // Exec command.
-      var child = exec(cmd, _.omit(options, 'direction'), function (err, stdout, stderr) {
-        if (err) return reject(err);
-        resolve({
-          child:  child,
-          stdout: stdout,
-          stderr: stderr
-        });
-      });
-
-      if (connection.options.stdout)
-        child.stdout.pipe(stdoutWrapper).pipe(connection.options.stdout);
-
-      if (connection.options.stderr)
-        child.stderr.pipe(stderrWrapper).pipe(connection.options.stderr);
-
-    })
-
-  }).nodeify(cb);
+  }.bind(this)).nodeify(cb);
 };
 
 /**
@@ -287,4 +357,21 @@ function buildSSHArgs(options) {
     args = args.concat(['-o',  'StrictHostKeyChecking=' + options.strict]);
 
   return args;
+}
+
+/**
+ * Build SCP command.
+ *
+ * @param {Connection} connection
+ * @param {string} from
+ * @param {string} to
+ * @returns {string}
+ */
+function buildSCPCommand(connection, from, to) {
+  // The command that transfers the file
+  var scp = ['scp'];
+  if (connection.remote.port) scp = scp.concat('-P', connection.remote.port);
+  if (connection.options.key) scp = scp.concat('-i', connection.options.key);
+  scp = scp.concat(from, to).join(' ');
+  return scp;
 }

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -299,12 +299,8 @@ Connection.prototype.copy = function (src, dest, options, cb) {
 
   return isRsyncAvailable().then(function (rsyncAvailable) {
 
-    return new Promise(function (resolve, reject) {
-
-      var copy = rsyncAvailable ? copyViaRsync : copyViaScp;
-      resolve(copy(options, this, src, dest));
-
-    }.bind(this))
+    var handler = rsyncAvailable ? copyViaRsync : copyViaScp;
+    return handler(options, this, src, dest);
 
   }.bind(this)).nodeify(cb);
 };

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "bluebird": "^2.9.14",
     "lodash": "^3.5.0",
-    "stream-line-wrapper": "^0.1.1"
+    "stream-line-wrapper": "^0.1.1",
+    "whereis": "^0.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "bluebird": "^2.9.14",
     "lodash": "^3.5.0",
+    "sprintf-js": "^1.0.2",
     "stream-line-wrapper": "^0.1.1",
     "whereis": "^0.4.0"
   }

--- a/test/connection-pool.js
+++ b/test/connection-pool.js
@@ -1,12 +1,14 @@
 var rewire = require('rewire');
 var expect = require('chai').use(require('sinon-chai')).expect;
 var childProcess = require('./mocks/child-process');
+var mockWhereis = require('./mocks/mock-whereis');
 var Connection = rewire('../lib/connection');
 var ConnectionPool = rewire('../lib/connection-pool');
 
 describe('SSH Connection pool', function () {
   beforeEach(function () {
     Connection.__set__('exec', childProcess.exec.bind(childProcess));
+    Connection.__set__('whereis', mockWhereis({rsync: '/bin/rsync'}));
     ConnectionPool.__set__('Connection', Connection);
   });
 

--- a/test/connection.js
+++ b/test/connection.js
@@ -210,8 +210,12 @@ describe('SSH Connection', function () {
     it('should use tar+scp where rsync is not available', function(done) {
       Connection.__set__('whereis', mockWhereis({}));
       connection.copy('/src/dir', '/dest/dir', function (err) {
-        expect(childProcess.exec).to.be.calledWith(
-          'cd /src; tar -czf dir.tar.gz dir; scp /src/dir.tar.gz user@host:/dest; ssh user@host "cd /dest; tar -xzf dir.tar.gz"');
+        expect(childProcess.exec).to.be.calledWith('cd /src && tar -czf dir.tmp.tar.gz dir');
+        expect(childProcess.exec).to.be.calledWith('ssh user@host "mkdir -p /dest/dir"');
+        expect(childProcess.exec).to.be.calledWith('scp /src/dir.tmp.tar.gz user@host:/dest/dir');
+        expect(childProcess.exec).to.be.calledWith('cd /src && rm dir.tmp.tar.gz');
+        expect(childProcess.exec).to.be.calledWith('ssh user@host "cd /dest/dir && tar --strip-components 1 -xzf dir.tmp.tar.gz"');
+        expect(childProcess.exec).to.be.calledWith('ssh user@host "cd /dest/dir && rm dir.tmp.tar.gz"');
         done(err);
       });
     });
@@ -219,8 +223,27 @@ describe('SSH Connection', function () {
     it('should accept "direction" option when using tar+scp', function(done) {
       Connection.__set__('whereis', mockWhereis({}));
       connection.copy('/src/dir', '/dest/dir', {direction: 'remoteToLocal'}, function (err) {
-        expect(childProcess.exec).to.be.calledWith(
-          'ssh user@host "cd /src; tar -czf dir.tar.gz dir"; scp user@host:/src/dir.tar.gz /dest; cd /dest; tar -xzf dir.tar.gz');
+        expect(childProcess.exec).to.be.calledWith('ssh user@host "cd /src && tar -czf dir.tmp.tar.gz dir"');
+        expect(childProcess.exec).to.be.calledWith('mkdir -p /dest/dir');
+        expect(childProcess.exec).to.be.calledWith('scp user@host:/src/dir.tmp.tar.gz /dest/dir');
+        expect(childProcess.exec).to.be.calledWith('ssh user@host "cd /src && rm dir.tmp.tar.gz"');
+        expect(childProcess.exec).to.be.calledWith('cd /dest/dir && tar --strip-components 1 -xzf dir.tmp.tar.gz');
+        expect(childProcess.exec).to.be.calledWith('cd /dest/dir && rm dir.tmp.tar.gz');
+        done(err);
+      });
+    });
+
+    it('should accept port and key when using tar+scp', function (done) {
+      Connection.__set__('whereis', mockWhereis({}));
+      connection = new Connection({
+        remote: 'user@host:12345',
+        key:    '/path/to/key'
+      });
+      connection.copy('/src/dir', '/dest/dir', function (err) {
+        expect(childProcess.exec).to.be.calledWith('ssh -p 12345 -i /path/to/key user@host "mkdir -p /dest/dir"');
+        expect(childProcess.exec).to.be.calledWith('scp -P 12345 -i /path/to/key /src/dir.tmp.tar.gz user@host:/dest/dir');
+        expect(childProcess.exec).to.be.calledWith('ssh -p 12345 -i /path/to/key user@host "cd /dest/dir && tar --strip-components 1 -xzf dir.tmp.tar.gz"');
+        expect(childProcess.exec).to.be.calledWith('ssh -p 12345 -i /path/to/key user@host "cd /dest/dir && rm dir.tmp.tar.gz"');
         done(err);
       });
     });
@@ -286,7 +309,7 @@ describe('SSH Connection', function () {
 
 
         var output = stdMocks.flush();
-        expect(output.stdout[0]).to.equal('Remote copy "/src/dir" to "user@host:/dest/dir"\n');
+        expect(output.stdout[0]).to.equal('Copy "/src/dir" to "user@host:/dest/dir" via rsync\n');
         expect(output.stdout[1].toString()).to.equal('@host first line\n');
 
         expect(output.stderr[0].toString()).to.equal('@host-err an error\n');

--- a/test/mocks/mock-whereis.js
+++ b/test/mocks/mock-whereis.js
@@ -1,0 +1,15 @@
+/**
+ * Creates a mock "whereis" function that accepts an array of predefined locations for binaries
+ * @param {Array.<string, string>} paths
+ * @returns {Function}
+ */
+var mockWhereis = function (paths) {
+  return function (name, cb) {
+    if (typeof paths[name] !== 'undefined')
+      cb(null, paths[name]);
+    else
+      cb(new Error('Could not find ' + name + ' on your system'));
+  };
+};
+
+module.exports = mockWhereis;


### PR DESCRIPTION
The system uses https://github.com/vvo/node-whereis to check whether `rsync` is available in the current environment and if it is, proceeds as normal. A shim function has been added that replicates `rsync` functionality by using `tar` and `scp` for when `rsync` is not available.
