### PR TITLE
Fix remote copy via scp on windows

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -240,6 +240,10 @@ function generateScpCommands(options, connection, src, dest) {
     [cdSource, ['tar'].concat(excludes).concat('-czf', packageFile, path.basename(src)).join(' ')].join(' && '),
     'src');
 
+   var copy = options.direction === 'localToRemote' ?
+    [cdSource, buildSCPCommand(connection, packageFile, toPath)].join(' && ') :
+    buildSCPCommand(connection, fromPath, toPath)
+
   // The command to untar the destination package
   var untar = generateCommand(
     [cdDest, ['tar'].concat('--strip-components', '1', '-xzf', packageFile).join(' ')].join(' && '),
@@ -248,7 +252,7 @@ function generateScpCommands(options, connection, src, dest) {
   return [
     tar,
     generateCommand(['mkdir', '-p', dest].join(' '), 'dest'),
-    buildSCPCommand(connection, fromPath, toPath),
+    copy,
     generateCommand([cdSource, ['rm', packageFile].join(' ')].join(' && '), 'src'),
     untar,
     generateCommand([cdDest, ['rm', packageFile].join(' ')].join(' && '), 'dest')

--- a/test/connection.js
+++ b/test/connection.js
@@ -213,7 +213,7 @@ describe('SSH Connection', function () {
       connection.copy('/src/dir', '/dest/dir', function (err) {
         expect(childProcess.exec).to.be.calledWith('cd /src && tar -czf dir.tmp.tar.gz dir');
         expect(childProcess.exec).to.be.calledWith('ssh user@host "mkdir -p /dest/dir"');
-        expect(childProcess.exec).to.be.calledWith('scp /src/dir.tmp.tar.gz user@host:/dest/dir');
+        expect(childProcess.exec).to.be.calledWith('cd /src && scp dir.tmp.tar.gz user@host:/dest/dir');
         expect(childProcess.exec).to.be.calledWith('cd /src && rm dir.tmp.tar.gz');
         expect(childProcess.exec).to.be.calledWith('ssh user@host "cd /dest/dir && tar --strip-components 1 -xzf dir.tmp.tar.gz"');
         expect(childProcess.exec).to.be.calledWith('ssh user@host "cd /dest/dir && rm dir.tmp.tar.gz"');
@@ -228,7 +228,7 @@ describe('SSH Connection', function () {
         Connection.__set__('path', path);
         expect(childProcess.exec).to.be.calledWith('cd c:\\src && tar -czf dir.tmp.tar.gz dir');
         expect(childProcess.exec).to.be.calledWith('ssh user@host "mkdir -p /dest/dir"');
-        expect(childProcess.exec).to.be.calledWith('scp /c/src/dir.tmp.tar.gz user@host:/dest/dir');
+        expect(childProcess.exec).to.be.calledWith('cd c:\\src && scp dir.tmp.tar.gz user@host:/dest/dir');
         expect(childProcess.exec).to.be.calledWith('cd c:\\src && rm dir.tmp.tar.gz');
         expect(childProcess.exec).to.be.calledWith('ssh user@host "cd /dest/dir && tar --strip-components 1 -xzf dir.tmp.tar.gz"');
         expect(childProcess.exec).to.be.calledWith('ssh user@host "cd /dest/dir && rm dir.tmp.tar.gz"');
@@ -257,7 +257,7 @@ describe('SSH Connection', function () {
       });
       connection.copy('/src/dir', '/dest/dir', function (err) {
         expect(childProcess.exec).to.be.calledWith('ssh -p 12345 -i /path/to/key user@host "mkdir -p /dest/dir"');
-        expect(childProcess.exec).to.be.calledWith('scp -P 12345 -i /path/to/key /src/dir.tmp.tar.gz user@host:/dest/dir');
+        expect(childProcess.exec).to.be.calledWith('cd /src && scp -P 12345 -i /path/to/key dir.tmp.tar.gz user@host:/dest/dir');
         expect(childProcess.exec).to.be.calledWith('ssh -p 12345 -i /path/to/key user@host "cd /dest/dir && tar --strip-components 1 -xzf dir.tmp.tar.gz"');
         expect(childProcess.exec).to.be.calledWith('ssh -p 12345 -i /path/to/key user@host "cd /dest/dir && rm dir.tmp.tar.gz"');
         done(err);


### PR DESCRIPTION
Hello,

when using Shipit on Windows inside Git Bash, the following error occured during remote copy :

```
Error: Command failed: scp /tmp/XXX.tmp.tar.gz user@server:XXX
/tmp/XXX.tmp.tar.gz: No such file or directory

    at ChildProcess.exithandler (child_process.js:206:12)
    at emitTwo (events.js:106:13)
    at ChildProcess.emit (events.js:191:7)
    at maybeClose (internal/child_process.js:877:16)
    at Socket.<anonymous> (internal/child_process.js:334:11)
    at emitOne (events.js:96:13)
    at Socket.emit (events.js:188:7)
    at Pipe._handle.close [as _onclose] (net.js:498:12)
```

I guess _scp.exe_ is confused with _/tmp_ and _/c/tmp_.

I try to play with the _rsyncFrom_ option but without success so here is a patch ressolving my issue.

Thanks and regards