### PR TITLE
Allow Passing Strict as a Boolean

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -373,7 +373,7 @@ function buildSSHArgs(options) {
   if (options.key)
     args = args.concat(['-i', options.key]);
 
-  if (options.strict)
+  if (options.strict !== undefined)
     args = args.concat(['-o', 'StrictHostKeyChecking=' + options.strict]);
 
   return args;


### PR DESCRIPTION
Hi!

## Problem
I am using `shipit` to deploy my projects and as long as I using it I am confronting a problem with `StrictHostKeyChecking`. At first, I tried to tinker with my CI configs, adding `StrictHostKeyChecking=false` as a build step, but then I found that in `shipit-cli` there are check for a `strict`-option in config: https://github.com/shipitjs/shipit/blob/master/lib/shipit.js#L143

I added it, but it didn't work:
```
shipit.initConfig({
  default: {
    // ...
    strict: false,
  }
})
```

It took me a while to understand that I need to pass that option as a string, not as boolean.

## Solution
I think it is not obvious that flag must be passed as a string, especially with that booleany name. So my offer is to check for `undefined` instead of a falsy value.

What do you think?